### PR TITLE
make userId required

### DIFF
--- a/packages/core/src/analytics.ts
+++ b/packages/core/src/analytics.ts
@@ -639,7 +639,7 @@ export class JournifyClient {
     await this.process(event);
   }
 
-  async identify(userId?: string, userTraits?: Traits) {
+  async identify(userId: string, userTraits?: Traits) {
     if (!userId) {
       throw new Error('userId is required to identify a user');
     }


### PR DESCRIPTION
This pull request includes a change to the `identify` method in the `JournifyClient` class to ensure that the `userId` parameter is always provided.

* [`packages/core/src/analytics.ts`](diffhunk://#diff-2314bbb804c0f51c83ca759280e95b1f747590ec500e4fa4ceab0a8bad8901e3L642-R642): Modified the `identify` method to make the `userId` parameter mandatory, ensuring that an error is thrown if `userId` is not provided.